### PR TITLE
Fix references to exemplar in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 -->
 
 <!-- markdownlint-disable-next-line line-length -->
-![Library Status](https://raw.githubusercontent.com/bemanproject/beman/refs/heads/main/images/badges/beman_badge-beman_library_under_development.svg) ![Continuous Integration Tests](https://github.com/bemanproject/cache_latest/actions/workflows/ci_tests.yml/badge.svg) [![Coverage](https://coveralls.io/repos/github/bemanproject/exemplar/badge.svg?branch=main)](https://coveralls.io/github/bemanproject/exemplar?branch=main) ![Standard Target](https://github.com/bemanproject/beman/blob/main/images/badges/cpp26.svg)
+![Library Status](https://raw.githubusercontent.com/bemanproject/beman/refs/heads/main/images/badges/beman_badge-beman_library_under_development.svg) ![Continuous Integration Tests](https://github.com/bemanproject/cache_latest/actions/workflows/ci_tests.yml/badge.svg) [![Coverage](https://coveralls.io/repos/github/bemanproject/cache_latest/badge.svg?branch=main)](https://coveralls.io/github/bemanproject/cache_latest?branch=main) ![Standard Target](https://github.com/bemanproject/beman/blob/main/images/badges/cpp26.svg)
 
 <!-- markdownlint-disable-next-line line-length -->
 `beman.cache_latest` is a C++ ranges adaptor that caches the result of the last dereference of the underlying iterator. The reason for doing this is efficiency - specifically avoiding extra iterator dereferences.
@@ -196,11 +196,11 @@ ctest --test-dir build
 When configuring the project manually,
 you can pass an array of project specific CMake configs to customize your build.
 
-Project specific options are prefixed with `BEMAN_EXEMPLAR`.
+Project specific options are prefixed with `BEMAN_CACHE_LATEST`.
 You can see the list of available options with:
 
 ```bash
-cmake -LH | grep "BEMAN_EXEMPLAR" -C 2
+cmake -LH | grep "BEMAN_CACHE_LATEST" -C 2
 ```
 
 <details>
@@ -215,7 +215,7 @@ Values: { ON, OFF }.
 You can configure the project to have this option turned off via:
 
 ```bash
-cmake -B build -S . -DCMAKE_CXX_STANDARD=20 -DBEMAN_EXEMPLAR_BUILD_TESTS=OFF
+cmake -B build -S . -DCMAKE_CXX_STANDARD=20 -DBEMAN_CACHE_LATEST_BUILD_TESTS=OFF
 ```
 
 > [!TIP]


### PR DESCRIPTION
Some of the CMake options previously weren't updated.

Also, 75f4e5ce914e621edb0accf9eebace6d87239449 neglected to update the coverage badge so it didn't point to exemplar.