### PR TITLE
fix: bump beman-tidy to v0.4.1 in pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -43,7 +43,7 @@ repos:
 
     # Beman Standard checking via beman-tidy
   - repo: https://github.com/bemanproject/beman-tidy
-    rev: v0.4.0
+    rev: v0.4.1
     hooks:
     - id: beman-tidy
 


### PR DESCRIPTION
Issue: https://github.com/bemanproject/beman-tidy/issues/254

## Summary

- Bumps `beman-tidy` pre-commit hook from `v0.4.0` → `v0.4.1`

