### PR TITLE
Update beman-tidy to 0.5.2

### DIFF
--- a/.beman-tidy.yaml
+++ b/.beman-tidy.yaml
@@ -4,7 +4,6 @@
 # Check documentation for beman-tidy here:
 # https://github.com/bemanproject/beman-tidy/blob/main/README.md
 
-disabled_rules:
-    # None
+disabled_rules: []
 ignored_paths:
-    # None
+    - infra/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -43,7 +43,7 @@ repos:
 
     # Beman Standard checking via beman-tidy
   - repo: https://github.com/bemanproject/beman-tidy
-    rev: v0.5.1
+    rev: v0.5.2
     hooks:
     - id: beman-tidy
 


### PR DESCRIPTION
## Summary

- Bump `beman-tidy` pre-commit hook to **0.5.2**
- Fix `.beman-tidy.yaml` null values (`# None` → `[]` / `[infra/]`) where present

## Test plan

- [ ] CI green
- [ ] `pre-commit run beman-tidy --all-files`